### PR TITLE
Make copyright headers non-doc comments

### DIFF
--- a/benchmarks/ctc.cpp
+++ b/benchmarks/ctc.cpp
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) Facebook, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the

--- a/benchmarks/functions.cpp
+++ b/benchmarks/functions.cpp
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) Facebook, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the

--- a/benchmarks/graph.cpp
+++ b/benchmarks/graph.cpp
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) Facebook, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the

--- a/benchmarks/parallel.cpp
+++ b/benchmarks/parallel.cpp
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) Facebook, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the

--- a/benchmarks/time_utils.h
+++ b/benchmarks/time_utils.h
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) Facebook, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the

--- a/bindings/python/gtn/_autograd.cpp
+++ b/bindings/python/gtn/_autograd.cpp
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) Facebook, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the

--- a/bindings/python/gtn/_creations.cpp
+++ b/bindings/python/gtn/_creations.cpp
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) Facebook, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the

--- a/bindings/python/gtn/_functions.cpp
+++ b/bindings/python/gtn/_functions.cpp
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) Facebook, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the

--- a/bindings/python/gtn/_graph.cpp
+++ b/bindings/python/gtn/_graph.cpp
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) Facebook, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the

--- a/bindings/python/gtn/_parallel.cpp
+++ b/bindings/python/gtn/_parallel.cpp
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) Facebook, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the

--- a/bindings/python/gtn/_rand.cpp
+++ b/bindings/python/gtn/_rand.cpp
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) Facebook, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the

--- a/bindings/python/gtn/_utils.cpp
+++ b/bindings/python/gtn/_utils.cpp
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) Facebook, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the

--- a/examples/asg.cpp
+++ b/examples/asg.cpp
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) Facebook, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the

--- a/examples/ctc.cpp
+++ b/examples/ctc.cpp
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) Facebook, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the

--- a/examples/learned_decompositions.cpp
+++ b/examples/learned_decompositions.cpp
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) Facebook, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the

--- a/examples/priors.cpp
+++ b/examples/priors.cpp
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) Facebook, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the

--- a/examples/tutorial.cpp
+++ b/examples/tutorial.cpp
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) Facebook, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the

--- a/gtn/autograd.cpp
+++ b/gtn/autograd.cpp
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) Facebook, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the

--- a/gtn/autograd.h
+++ b/gtn/autograd.h
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) Facebook, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the

--- a/gtn/creations.cpp
+++ b/gtn/creations.cpp
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) Facebook, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the

--- a/gtn/creations.h
+++ b/gtn/creations.h
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) Facebook, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the

--- a/gtn/functions.cpp
+++ b/gtn/functions.cpp
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) Facebook, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the

--- a/gtn/functions.h
+++ b/gtn/functions.h
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) Facebook, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the

--- a/gtn/functions/compose.cpp
+++ b/gtn/functions/compose.cpp
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) Facebook, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the

--- a/gtn/functions/compose.h
+++ b/gtn/functions/compose.h
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) Facebook, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the

--- a/gtn/functions/shortest.cpp
+++ b/gtn/functions/shortest.cpp
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) Facebook, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the

--- a/gtn/functions/shortest.h
+++ b/gtn/functions/shortest.h
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) Facebook, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the

--- a/gtn/graph.cpp
+++ b/gtn/graph.cpp
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) Facebook, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the

--- a/gtn/graph.h
+++ b/gtn/graph.h
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) Facebook, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the

--- a/gtn/gtn.h
+++ b/gtn/gtn.h
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) Facebook, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the

--- a/gtn/parallel.h
+++ b/gtn/parallel.h
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) Facebook, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the

--- a/gtn/parallel/parallel_map.cpp
+++ b/gtn/parallel/parallel_map.cpp
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) Facebook, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the

--- a/gtn/parallel/parallel_map.h
+++ b/gtn/parallel/parallel_map.h
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) Facebook, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the

--- a/gtn/parallel/thread_pool.h
+++ b/gtn/parallel/thread_pool.h
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) Facebook, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the

--- a/gtn/rand.cpp
+++ b/gtn/rand.cpp
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) Facebook, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the

--- a/gtn/rand.h
+++ b/gtn/rand.h
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) Facebook, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the

--- a/gtn/utils.cpp
+++ b/gtn/utils.cpp
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) Facebook, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the

--- a/gtn/utils.h
+++ b/gtn/utils.h
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) Facebook, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the

--- a/test/autograd_test.cpp
+++ b/test/autograd_test.cpp
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) Facebook, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the

--- a/test/creations_test.cpp
+++ b/test/creations_test.cpp
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) Facebook, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the

--- a/test/criterion_test.cpp
+++ b/test/criterion_test.cpp
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) Facebook, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the

--- a/test/functions_test.cpp
+++ b/test/functions_test.cpp
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) Facebook, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the

--- a/test/graph_test.cpp
+++ b/test/graph_test.cpp
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) Facebook, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the

--- a/test/parallel_test.cpp
+++ b/test/parallel_test.cpp
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) Facebook, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the

--- a/test/rand_test.cpp
+++ b/test/rand_test.cpp
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) Facebook, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the

--- a/test/utils_test.cpp
+++ b/test/utils_test.cpp
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) Facebook, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the


### PR DESCRIPTION
tl;dr:
```
echo "*
 * Copyright" > test.correct.txt
```
Remove trailing newline:
```
head -c -1 test.correct.txt > test.correct.2.txt
```

Replace with some `perl`:
```
find . -type f \( -name "*.cpp" -o -name "*.h" -o -name "*.cuh" -o -name "*.cu"  -o -name "*.hpp" \) | xargs perl -i -p0e 's/\*\*\n \* Copyright/`cat test.correct.2.txt`/se'
```

Before:
<img width="809" alt="Screen Shot 2020-09-30 at 1 05 11 PM" src="https://user-images.githubusercontent.com/7871817/94736084-87f8d300-0320-11eb-9e77-aeb93656ec47.png">

After:
<img width="786" alt="Screen Shot 2020-09-30 at 1 27 04 PM" src="https://user-images.githubusercontent.com/7871817/94736187-abbc1900-0320-11eb-9a0b-3fede3553cbb.png">
