### PR TITLE
Get tmp dir based on OS for utils_test

### DIFF
--- a/test/utils_test.cpp
+++ b/test/utils_test.cpp
@@ -28,18 +28,20 @@ std::string getTmpFileName() {
   if (user != nullptr) {
     userstr = std::string(user);
   }
-  // tmp dir
-  char* dir1 = std::getenv("TMPDIR");
-  std::string tmpdir = "";
-  if (dir1 != nullptr) {
-    tmpdir = std::string(dir1);
-  }
-  char* dir2 = std::getenv("TMP");
-  if (dir2 != nullptr) {
-    tmpdir = std::string(dir2);
-  }
 
-  return tmpdir + "_test" + userstr + ".graph";
+  // tmp dir
+  std::string tmpDir = "/tmp";
+  auto getTmpDir = [&tmpDir](const std::string& env) {
+    char* dir = std::getenv(env.c_str());
+    if (dir != nullptr) {
+      tmpDir = std::string(dir);
+    }
+  };
+  getTmpDir("TMPDIR");
+  getTmpDir("TEMP");
+  getTmpDir("TMP");
+
+  return tmpDir + "/test_" + userstr + ".graph";
 }
 } // namespace
 

--- a/test/utils_test.cpp
+++ b/test/utils_test.cpp
@@ -8,6 +8,7 @@
 #define CATCH_CONFIG_MAIN
 
 #include <cmath>
+#include <cstdlib>
 #include <iostream>
 #include <sstream>
 #include <string>
@@ -27,7 +28,18 @@ std::string getTmpFileName() {
   if (user != nullptr) {
     userstr = std::string(user);
   }
-  return std::string("/tmp/test_") + userstr + std::string(".graph");
+  // tmp dir
+  char* dir1 = std::getenv("TMPDIR");
+  std::string tmpdir = "";
+  if (dir1 != nullptr) {
+    tmpdir = std::string(dir1);
+  }
+  char* dir2 = std::getenv("TMP");
+  if (dir2 != nullptr) {
+    tmpdir = std::string(dir2);
+  }
+
+  return tmpdir + "_test" + userstr + ".graph";
 }
 } // namespace
 


### PR DESCRIPTION
Makes the test portable so it works on non-Unix-based systems, i.e. [`TMPDIR` or `TMP`](https://en.wikipedia.org/wiki/TMPDIR).