### PR TITLE
MSVC and Windows support

### DIFF
--- a/benchmarks/ctc.cpp
+++ b/benchmarks/ctc.cpp
@@ -39,10 +39,10 @@ std::vector<float> randVec(int num) {
 
 Graph ctcGraph(const std::vector<int>& target) {
   int blank = 0;
-  int L = 2 * target.size() + 1;
+  size_t L = 2 * target.size() + 1;
   Graph ctc;
-  for (int l = 0; l < L; l++) {
-    int idx = (l - 1) / 2;
+  for (size_t l = 0; l < L; l++) {
+    size_t idx = (l - 1) / 2;
     ctc.addNode(l == 0, l == L - 1 || l == L - 2);
     int label = l % 2 ? target[idx] : blank;
     ctc.addArc(l, l, label);

--- a/benchmarks/ctc.cpp
+++ b/benchmarks/ctc.cpp
@@ -6,6 +6,7 @@
  */
 
 #include <math.h>
+#include <string>
 
 #include "benchmarks/time_utils.h"
 #include "gtn/gtn.h"

--- a/benchmarks/parallel.cpp
+++ b/benchmarks/parallel.cpp
@@ -5,6 +5,8 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+#include <string>
+
 #include "benchmarks/time_utils.h"
 #include "gtn/gtn.h"
 

--- a/bindings/python/gtn/_graph.cpp
+++ b/bindings/python/gtn/_graph.cpp
@@ -27,14 +27,15 @@ PYBIND11_MODULE(_graph, m) {
           py::overload_cast<bool, bool>(&Graph::addNode),
           "start"_a = false,
           "accept"_a = false)
-      .def("add_arc",
-          py::overload_cast<int, int, int>(&Graph::addArc),
+      .def(
+          "add_arc",
+          py::overload_cast<size_t, size_t, int>(&Graph::addArc),
           "src_node"_a,
           "dst_node"_a,
           "label"_a)
       .def(
           "add_arc",
-          py::overload_cast<int, int, int, int, float>(&Graph::addArc),
+          py::overload_cast<size_t, size_t, int, int, float>(&Graph::addArc),
           "src_node"_a,
           "dst_node"_a,
           "ilabel"_a,
@@ -47,7 +48,8 @@ PYBIND11_MODULE(_graph, m) {
       .def("num_accept", &Graph::numAccept)
       .def("is_grad_available", &Graph::isGradAvailable)
       .def("item", &Graph::item)
-      .def("arc_sort",
+      .def(
+          "arc_sort",
           [](Graph& g, bool olabel) {
             py::gil_scoped_release release;
             g.arcSort(olabel);
@@ -106,8 +108,8 @@ PYBIND11_MODULE(_graph, m) {
       });
   m.attr("epsilon") = epsilon;
 #ifdef VERSION_INFO
-    m.attr("__version__") = VERSION_INFO;
+  m.attr("__version__") = VERSION_INFO;
 #else
-    m.attr("__version__") = "dev";
+  m.attr("__version__") = "dev";
 #endif
 }

--- a/examples/ctc.cpp
+++ b/examples/ctc.cpp
@@ -48,7 +48,8 @@ int main() {
   int N = 28; // size of alphabet (arcs per step)
   int T = 5; // length of input
   std::vector<int> output = {3, 1, 20}; // corresponds to 'c', 'a', 't'
-  Graph ctc = createCtcTargetGraph(output, 0 /* blank idx */); // https://git.io/JUKAZ
+  Graph ctc =
+      createCtcTargetGraph(output, 0 /* blank idx */); // https://git.io/JUKAZ
 
   // Emission graph
   Graph emissions = linearGraph(T, N);

--- a/examples/ctc.cpp
+++ b/examples/ctc.cpp
@@ -19,8 +19,8 @@ using namespace gtn;
  */
 
 Graph createCtcTargetGraph(const std::vector<int>& target, int blank) {
-  int L = target.size();
-  int U = 2 * L + 1; // # c # a # t #
+  size_t L = target.size();
+  size_t U = 2 * L + 1; // # c # a # t #
   Graph ctc;
   for (int l = 0; l < U; l++) {
     int idx = (l - 1) / 2;

--- a/gtn/functions.cpp
+++ b/gtn/functions.cpp
@@ -120,15 +120,15 @@ Graph concat(const std::vector<Graph>& graphs) {
     out.addNode(true, true);
     return out;
   }
-  int nodeOffset = 0;
-  for (auto i = 0; i < graphs.size(); ++i) {
+  size_t nodeOffset = 0;
+  for (size_t i = 0; i < graphs.size(); ++i) {
     auto& graph = graphs[i];
-    for (auto n = 0; n < graph.numNodes(); ++n) {
+    for (size_t n = 0; n < graph.numNodes(); ++n) {
       out.addNode(
           (i == 0) && graph.isStart(n),
           (i == graphs.size() - 1) && graph.isAccept(n));
     }
-    for (auto a = 0; a < graph.numArcs(); ++a) {
+    for (size_t a = 0; a < graph.numArcs(); ++a) {
       out.addArc(
           nodeOffset + graph.srcNode(a),
           nodeOffset + graph.dstNode(a),
@@ -203,7 +203,7 @@ Graph union_(const std::vector<Graph>& graphs) {
   Graph out(gradFunc, std::move(inputs));
 
   // Add all the nodes in a predictable order
-  int nodeOffset = 0;
+  size_t nodeOffset = 0;
   for (auto& graph : graphs) {
     for (auto n = 0; n < graph.numNodes(); ++n) {
       out.addNode(graph.isStart(n), graph.isAccept(n));

--- a/gtn/functions/shortest.cpp
+++ b/gtn/functions/shortest.cpp
@@ -36,23 +36,23 @@ void shortestDistanceGrad(
     const Graph& deltas,
     const std::vector<float>& nodeScores,
     const std::vector<float>& maxScoresCache,
-    const std::vector<int>& maxArcIdxCache,
+    const std::vector<size_t>& maxArcIdxCache,
     bool tropical) {
   std::queue<int> computed;
-  std::vector<int> degrees(g.numNodes());
+  std::vector<size_t> degrees(g.numNodes());
   std::vector<float> nodeGrads(g.numNodes(), 0.0);
   std::vector<float> arcGrads(g.numArcs(), 0.0);
   for (auto n = 0; n < g.numNodes(); ++n) {
     degrees[n] = g.numOut(n);
   }
   float curScore = 0.0;
-  float denom = tropical ? 0.0 : std::exp(output - maxScoresCache.back());
+  float denom = tropical ? 0.0f : std::exp(output - maxScoresCache.back());
   for (auto n : g.accept()) {
     if (g.numOut(n) == 0) {
       computed.push(n);
     }
     if (tropical) {
-      curScore = (n == maxArcIdxCache.back()) ? 1.0 : 0.0;
+      curScore = (n == maxArcIdxCache.back()) ? 1.0f : 0.0f;
     } else {
       curScore = std::exp(nodeScores[n] - maxScoresCache.back()) / denom;
     }
@@ -62,11 +62,11 @@ void shortestDistanceGrad(
   while (!computed.empty()) {
     auto n = computed.front();
     computed.pop();
-    denom = tropical ? 0.0 : std::exp(nodeScores[n] - maxScoresCache[n]);
+    denom = tropical ? 0.0f : std::exp(nodeScores[n] - maxScoresCache[n]);
     for (const auto a : g.in(n)) {
       auto un = g.srcNode(a);
       if (tropical) {
-        curScore = (a == maxArcIdxCache[n]) ? nodeGrads[n] : 0.0;
+        curScore = (a == maxArcIdxCache[n]) ? nodeGrads[n] : 0.0f;
       } else {
         curScore = nodeGrads[n] *
             std::exp(nodeScores[un] + g.weight(a) - maxScoresCache[n]) / denom;
@@ -88,9 +88,9 @@ Graph shortestDistance(const Graph& g, bool tropical /* = false */) {
   // List of scores and list of in degrees for each node
   std::vector<float> scores(g.numNodes());
   std::vector<float> maxScoresCache(g.numNodes() + 1, kNegInf);
-  std::vector<int> maxArcIdxCache(g.numNodes() + 1, -1);
-  std::vector<int> degrees(g.numNodes());
-  for (auto n = 0; n < g.numNodes(); ++n) {
+  std::vector<size_t> maxArcIdxCache(g.numNodes() + 1, -1);
+  std::vector<size_t> degrees(g.numNodes());
+  for (size_t n = 0; n < g.numNodes(); ++n) {
     degrees[n] = g.numIn(n);
   }
   for (auto n : g.start()) {

--- a/gtn/functions/shortest.cpp
+++ b/gtn/functions/shortest.cpp
@@ -190,11 +190,11 @@ Graph shortestDistance(const Graph& g, bool tropical /* = false */) {
 Graph shortestPath(const Graph& g) {
   std::queue<int> computed;
   // List of in degrees for each node
-  std::vector<int> degrees(g.numNodes());
+  std::vector<size_t> degrees(g.numNodes());
   // List of scores and backpointers for each node
   std::vector<int> backPointers(g.numNodes());
   std::vector<float> scores(g.numNodes(), kNegInf);
-  for (auto n = 0; n < g.numNodes(); ++n) {
+  for (size_t n = 0; n < g.numNodes(); ++n) {
     degrees[n] = g.numIn(n);
   }
   for (auto n : g.start()) {

--- a/gtn/graph.cpp
+++ b/gtn/graph.cpp
@@ -55,7 +55,8 @@ size_t Graph::addArc(
     float weight /* = 0 */) {
   assert(ilabel >= epsilon && olabel >= epsilon);
   int idx = static_cast<int>(numArcs());
-  sharedGraph_->arcs.emplace_back(static_cast<int>(srcNode), static_cast<int>(dstNode), ilabel, olabel);
+  sharedGraph_->arcs.emplace_back(
+      static_cast<int>(srcNode), static_cast<int>(dstNode), ilabel, olabel);
   sharedWeights_->push_back(weight);
   node(srcNode).out.push_back(idx);
   node(dstNode).in.push_back(idx);

--- a/gtn/graph.cpp
+++ b/gtn/graph.cpp
@@ -30,7 +30,7 @@ Graph::Graph(bool calcGrad /* = true */) {
 }
 
 int Graph::addNode(bool start /* = false */, bool accept /* = false */) {
-  int idx = numNodes();
+  int idx = static_cast<int>(numNodes());
   sharedGraph_->nodes.emplace_back(start, accept);
   if (start) {
     sharedGraph_->start.push_back(idx);
@@ -43,19 +43,19 @@ int Graph::addNode(bool start /* = false */, bool accept /* = false */) {
   return idx;
 }
 
-int Graph::addArc(int srcNode, int dstNode, int label) {
+size_t Graph::addArc(size_t srcNode, size_t dstNode, int label) {
   return addArc(srcNode, dstNode, label, label);
 }
 
-int Graph::addArc(
-    int srcNode,
-    int dstNode,
+size_t Graph::addArc(
+    size_t srcNode,
+    size_t dstNode,
     int ilabel,
     int olabel,
     float weight /* = 0 */) {
   assert(ilabel >= epsilon && olabel >= epsilon);
-  auto idx = numArcs();
-  sharedGraph_->arcs.emplace_back(srcNode, dstNode, ilabel, olabel);
+  int idx = static_cast<int>(numArcs());
+  sharedGraph_->arcs.emplace_back(static_cast<int>(srcNode), static_cast<int>(dstNode), ilabel, olabel);
   sharedWeights_->push_back(weight);
   node(srcNode).out.push_back(idx);
   node(dstNode).in.push_back(idx);

--- a/gtn/graph.h
+++ b/gtn/graph.h
@@ -12,8 +12,8 @@
 #include <cstdint>
 #include <functional>
 #include <memory>
-#include <vector>
 #include <mutex>
+#include <vector>
 
 namespace gtn {
 
@@ -73,7 +73,6 @@ class Graph {
   };
 
  public:
-
   using GradFunc =
       std::function<void(std::vector<Graph>& inputs, Graph& deltas)>;
   Graph(GradFunc gradFunc, std::vector<Graph> inputs);
@@ -318,8 +317,8 @@ class Graph {
   /** @} */
 
   /** \defgroup nodeAccess Node accessors
-    *  @{
-    */
+   *  @{
+   */
 
   /** Get the indices of the start nodes of the graph. */
   const std::vector<int>& start() const {
@@ -373,8 +372,8 @@ class Graph {
   /** @}*/
 
   /** \defgroup arcAccess Arc accessors
-    *  @{
-    */
+   *  @{
+   */
 
   /** The destination node of the `i`-th arc. */
   int srcNode(size_t i) const {

--- a/gtn/graph.h
+++ b/gtn/graph.h
@@ -124,19 +124,19 @@ class Graph {
       float weight = 0.0);
 
   /** The number of arcs in the graph. */
-  int numArcs() const {
+  size_t numArcs() const {
     return sharedGraph_->arcs.size();
   };
   /** The number of nodes in the graph. */
-  int numNodes() const {
+  size_t numNodes() const {
     return sharedGraph_->nodes.size();
   };
   /** The number of starting nodes in the graph. */
-  int numStart() const {
+  size_t numStart() const {
     return sharedGraph_->start.size();
   };
   /** The number of accepting nodes in the graph. */
-  int numAccept() const {
+  size_t numAccept() const {
     return sharedGraph_->accept.size();
   };
 
@@ -346,7 +346,7 @@ class Graph {
     }
   };
   /** The number of outgoing arcs from the `i`-th node. */
-  int numOut(int i) const {
+  size_t numOut(int i) const {
     return node(i).out.size();
   }
   /** Get the indices of outgoing arcs from the `i`-th node. */
@@ -358,7 +358,7 @@ class Graph {
     return node(i).out[j];
   }
   /** The number of incoming arcs to the `i`-th node. */
-  int numIn(int i) const {
+  size_t numIn(int i) const {
     return node(i).in.size();
   }
   /** Get the indices of incoming arcs to the `i`-th node. */
@@ -414,20 +414,20 @@ class Graph {
   int addArc(int srcNode, int dstNode, int label, float) = delete;
   int addArc(int srcNode, int dstNode, int label, double) = delete;
 
-  const Node& node(int i) const {
+  const Node& node(size_t i) const {
     // NB: assert gets stripped at in release mode
     assert(i >= 0 && i < numNodes());
     return sharedGraph_->nodes[i];
   }
-  Node& node(int i) {
+  Node& node(size_t i) {
     return const_cast<Node&>(static_cast<const Graph&>(*this).node(i));
   }
-  const Arc& arc(int i) const {
+  const Arc& arc(size_t i) const {
     // NB: assert gets stripped at in release mode
     assert(i >= 0 && i < numArcs());
     return sharedGraph_->arcs[i];
   }
-  Arc& arc(int i) {
+  Arc& arc(size_t i) {
     return const_cast<Arc&>(static_cast<const Graph&>(*this).arc(i));
   }
 

--- a/gtn/graph.h
+++ b/gtn/graph.h
@@ -105,7 +105,7 @@ class Graph {
    * @param label The arc label.
    * @return The id of the added arc.
    */
-  int addArc(int srcNode, int dstNode, int label);
+  size_t addArc(size_t srcNode, size_t dstNode, int label);
 
   /**
    * Add a arc between two nodes.
@@ -116,9 +116,9 @@ class Graph {
    * @param weight The arc weight.
    * @return The id of the added arc.
    */
-  int addArc(
-      int srcNode,
-      int dstNode,
+  size_t addArc(
+      size_t srcNode,
+      size_t dstNode,
       int ilabel,
       int olabel,
       float weight = 0.0);
@@ -330,43 +330,43 @@ class Graph {
     return sharedGraph_->accept;
   };
   /** Check if the `i`-th node is a start node. */
-  bool isStart(int i) const {
+  bool isStart(size_t i) const {
     return node(i).start;
   };
   /** Check if the `i`-th node is an accepting node. */
-  bool isAccept(int i) const {
+  bool isAccept(size_t i) const {
     return node(i).accept;
   };
   /** Make the the `i`-th node an accepting node. */
-  void makeAccept(int i) {
+  void makeAccept(size_t i) {
     auto& n = node(i);
     if (!n.accept) {
-      sharedGraph_->accept.push_back(i);
+      sharedGraph_->accept.push_back(static_cast<int>(i));
       n.accept = true;
     }
   };
   /** The number of outgoing arcs from the `i`-th node. */
-  size_t numOut(int i) const {
+  size_t numOut(size_t i) const {
     return node(i).out.size();
   }
   /** Get the indices of outgoing arcs from the `i`-th node. */
-  const std::vector<int>& out(int i) const {
+  const std::vector<int>& out(size_t i) const {
     return node(i).out;
   }
   /** Get the index of the `j`-th outgoing arc from the `i`-th node. */
-  int out(int i, int j) const {
+  int out(size_t i, size_t j) const {
     return node(i).out[j];
   }
   /** The number of incoming arcs to the `i`-th node. */
-  size_t numIn(int i) const {
+  size_t numIn(size_t i) const {
     return node(i).in.size();
   }
   /** Get the indices of incoming arcs to the `i`-th node. */
-  const std::vector<int>& in(int i) const {
+  const std::vector<int>& in(size_t i) const {
     return node(i).in;
   }
   /** Get the index of the `j`-th incoming arc to the `i`-th node. */
-  int in(int i, int j) const {
+  size_t in(size_t i, size_t j) const {
     return node(i).in[j];
   }
 
@@ -377,33 +377,33 @@ class Graph {
     */
 
   /** The destination node of the `i`-th arc. */
-  int srcNode(int i) const {
+  int srcNode(size_t i) const {
     return arc(i).srcNode;
   }
   /** The source node of the `i`-th arc. */
-  int dstNode(int i) const {
+  int dstNode(size_t i) const {
     return arc(i).dstNode;
   }
   /** The label of the `i`-th arc (use this for acceptors). */
-  int label(int i) const {
+  int label(size_t i) const {
     return arc(i).ilabel;
   }
   /** The input label of the `i`-th arc. */
-  int ilabel(int i) const {
+  int ilabel(size_t i) const {
     return arc(i).ilabel;
   }
   /** The output label of the `i`-th arc. */
-  int olabel(int i) const {
+  int olabel(size_t i) const {
     return arc(i).olabel;
   }
 
   /** The weight of the `i`-th arc. */
-  float weight(int i) const {
+  float weight(size_t i) const {
     assert(sharedWeights_ != nullptr);
     return (*sharedWeights_)[i];
   }
   /** Set the weight of the `i`-th arc. */
-  void setWeight(int i, float weight) {
+  void setWeight(size_t i, float weight) {
     assert(sharedWeights_ != nullptr);
     (*sharedWeights_)[i] = weight;
   }
@@ -411,8 +411,8 @@ class Graph {
 
  private:
   // Attempt to keep code like `g.addArc(n1, n2, 0, 2.0)` from compiling
-  int addArc(int srcNode, int dstNode, int label, float) = delete;
-  int addArc(int srcNode, int dstNode, int label, double) = delete;
+  size_t addArc(size_t srcNode, size_t dstNode, int label, float) = delete;
+  size_t addArc(size_t srcNode, size_t dstNode, int label, double) = delete;
 
   const Node& node(size_t i) const {
     // NB: assert gets stripped at in release mode

--- a/gtn/rand.cpp
+++ b/gtn/rand.cpp
@@ -17,7 +17,7 @@ Graph sample(const Graph& g, size_t maxLength /* = 1000 */) {
   }
 
   std::vector<int> arcs;
-  auto node = g.start()[rand() % g.numStart()];
+  size_t node = g.start()[rand() % g.numStart()];
   size_t acceptLength = 0;
   for (size_t length = 0; length < maxLength + 1; length++) {
     auto mod = g.numOut(node) + g.isAccept(node);

--- a/gtn/rand.cpp
+++ b/gtn/rand.cpp
@@ -30,7 +30,7 @@ Graph sample(const Graph& g, size_t maxLength /* = 1000 */) {
 
     // Select a random arc with optional transition to "final state" if node is
     // accepting
-    auto i = rand() % mod;
+    auto i = static_cast<int>(rand() % mod);
 
     // Successful and complete
     if (i == g.numOut(node)) {

--- a/gtn/utils.cpp
+++ b/gtn/utils.cpp
@@ -8,6 +8,7 @@
 #include "gtn/utils.h"
 
 #include <algorithm>
+#include <string>
 #include <list>
 #include <unordered_set>
 
@@ -140,7 +141,7 @@ bool isomorphic(const Graph& g1, const Graph& g2) {
 
 void save(std::ostream& out, const Graph& g) {
   // save num_nodes, num_arcs,  num_start_nodes, num_accept_nodes
-  std::vector<int> nums = {
+  std::vector<size_t> nums = {
       g.numNodes(), g.numArcs(), g.numStart(), g.numAccept()};
   out.write(
       reinterpret_cast<const char*>(nums.data()), nums.size() * sizeof(int));

--- a/gtn/utils.cpp
+++ b/gtn/utils.cpp
@@ -8,8 +8,8 @@
 #include "gtn/utils.h"
 
 #include <algorithm>
-#include <string>
 #include <list>
+#include <string>
 #include <unordered_set>
 
 namespace gtn {
@@ -141,8 +141,11 @@ bool isomorphic(const Graph& g1, const Graph& g2) {
 
 void save(std::ostream& out, const Graph& g) {
   // save num_nodes, num_arcs,  num_start_nodes, num_accept_nodes
-  std::vector<size_t> nums = {
-      g.numNodes(), g.numArcs(), g.numStart(), g.numAccept()};
+  std::vector<int> nums = {
+      static_cast<int>(g.numNodes()),
+      static_cast<int>(g.numArcs()),
+      static_cast<int>(g.numStart()),
+      static_cast<int>(g.numAccept())};
   out.write(
       reinterpret_cast<const char*>(nums.data()), nums.size() * sizeof(int));
 
@@ -158,7 +161,7 @@ void save(std::ostream& out, const Graph& g) {
       accept.size() * sizeof(int));
 
   // save arcs
-  for (int i = 0; i < g.numArcs(); i++) {
+  for (size_t i = 0; i < g.numArcs(); i++) {
     std::vector<int> indexes = {
         g.srcNode(i), g.dstNode(i), g.ilabel(i), g.olabel(i)};
     out.write(
@@ -349,9 +352,7 @@ Graph load(std::istream&& in) {
   return load(in);
 }
 
-void saveTxt(
-    const std::string& fileName,
-    const Graph& g) {
+void saveTxt(const std::string& fileName, const Graph& g) {
   std::ofstream out(fileName);
   saveTxt(out, g);
 }

--- a/test/criterion_test.cpp
+++ b/test/criterion_test.cpp
@@ -35,8 +35,8 @@ Graph emissions_graph(
 }
 
 Graph ctc_graph(std::vector<int> target, int blank) {
-  int L = target.size();
-  int U = 2 * L + 1;
+  size_t L = target.size();
+  size_t U = 2 * L + 1;
   Graph ctc;
   for (int l = 0; l < U; l++) {
     int idx = (l - 1) / 2;
@@ -259,7 +259,8 @@ TEST_CASE("Test ASG", "[criterion.asg]") {
 
     Graph fal;
     fal.addNode(true);
-    for (size_t l = 1; l <= target.size(); l++) {
+    for (size_t _l = 1; _l <= target.size(); _l++) {
+      int l = static_cast<int>(_l);
       fal.addNode(false, l == target.size());
       fal.addArc(l - 1, l, target[l - 1]);
       fal.addArc(l, l, target[l - 1]);

--- a/test/functions_test.cpp
+++ b/test/functions_test.cpp
@@ -38,15 +38,15 @@ TEST_CASE("Test Scalar Ops", "[functions.scalars]") {
 TEST_CASE("Test Project/clone", "[functions.clone]") {
   Graph graph =
       loadTxt(std::stringstream("0 1\n"
-                             "3 4\n"
-                             "0 1 0 2 2\n"
-                             "0 2 1 3 1\n"
-                             "1 2 0 1 2\n"
-                             "2 3 0 0 1\n"
-                             "2 3 1 2 1\n"
-                             "1 4 0 1 2\n"
-                             "2 4 1 1 3\n"
-                             "3 4 0 2 2\n"));
+                                "3 4\n"
+                                "0 1 0 2 2\n"
+                                "0 2 1 3 1\n"
+                                "1 2 0 1 2\n"
+                                "2 3 0 0 1\n"
+                                "2 3 1 2 1\n"
+                                "1 4 0 1 2\n"
+                                "2 4 1 1 3\n"
+                                "3 4 0 2 2\n"));
 
   // Test clone
   Graph cloned = clone(graph);
@@ -55,29 +55,29 @@ TEST_CASE("Test Project/clone", "[functions.clone]") {
   // Test projecting input
   Graph inputExpected =
       loadTxt(std::stringstream("0 1\n"
-                             "3 4\n"
-                             "0 1 0 0 2\n"
-                             "0 2 1 1 1\n"
-                             "1 2 0 0 2\n"
-                             "2 3 0 0 1\n"
-                             "2 3 1 1 1\n"
-                             "1 4 0 0 2\n"
-                             "2 4 1 1 3\n"
-                             "3 4 0 0 2\n"));
+                                "3 4\n"
+                                "0 1 0 0 2\n"
+                                "0 2 1 1 1\n"
+                                "1 2 0 0 2\n"
+                                "2 3 0 0 1\n"
+                                "2 3 1 1 1\n"
+                                "1 4 0 0 2\n"
+                                "2 4 1 1 3\n"
+                                "3 4 0 0 2\n"));
   CHECK(equal(projectInput(graph), inputExpected));
 
   // Test projecting output
   Graph outputExpected =
       loadTxt(std::stringstream("0 1\n"
-                             "3 4\n"
-                             "0 1 2 2 2\n"
-                             "0 2 3 3 1\n"
-                             "1 2 1 1 2\n"
-                             "2 3 0 0 1\n"
-                             "2 3 2 2 1\n"
-                             "1 4 1 1 2\n"
-                             "2 4 1 1 3\n"
-                             "3 4 2 2 2\n"));
+                                "3 4\n"
+                                "0 1 2 2 2\n"
+                                "0 2 3 3 1\n"
+                                "1 2 1 1 2\n"
+                                "2 3 0 0 1\n"
+                                "2 3 2 2 1\n"
+                                "1 4 1 1 2\n"
+                                "2 4 1 1 3\n"
+                                "3 4 2 2 2\n"));
   CHECK(equal(projectOutput(graph), outputExpected));
 }
 

--- a/test/functions_test.cpp
+++ b/test/functions_test.cpp
@@ -191,7 +191,7 @@ TEST_CASE("Test Composition", "[functions.compose]") {
     g1.addNode(false, true);
     for (int i = 0; i < g1.numNodes() - 1; i++) {
       for (int j = 0; j < 3; j++) {
-        g1.addArc(i, i + 1, j, j, j);
+        g1.addArc(i, i + 1, j, j, static_cast<float>(j));
       }
     }
 

--- a/test/graph_test.cpp
+++ b/test/graph_test.cpp
@@ -158,15 +158,15 @@ TEST_CASE("Test id", "[Graph::id]") {
 TEST_CASE("Test copy", "[Graph::deepCopy]") {
   Graph graph =
       loadTxt(std::stringstream("0 1\n"
-                             "3 4\n"
-                             "0 1 0 2 2\n"
-                             "0 2 1 3 1\n"
-                             "1 2 0 1 2\n"
-                             "2 3 0 0 1\n"
-                             "2 3 1 2 1\n"
-                             "1 4 0 1 2\n"
-                             "2 4 1 1 3\n"
-                             "3 4 0 2 2\n"));
+                                "3 4\n"
+                                "0 1 0 2 2\n"
+                                "0 2 1 3 1\n"
+                                "1 2 0 1 2\n"
+                                "2 3 0 0 1\n"
+                                "2 3 1 2 1\n"
+                                "1 4 0 1 2\n"
+                                "2 4 1 1 3\n"
+                                "3 4 0 2 2\n"));
 
   // Test copy
   Graph copied = Graph::deepCopy(graph);
@@ -232,9 +232,7 @@ TEST_CASE("Test gradient functionality", "[graph grad]") {
     CHECK_THROWS(g.grad());
 
     // this should be a no-op
-    g.setGradFunc([](std::vector<Graph>&, Graph&) {
-        return Graph{}; }
-    );
+    g.setGradFunc([](std::vector<Graph>&, Graph&) { return Graph{}; });
     CHECK(g.gradFunc() == nullptr);
   }
 
@@ -383,7 +381,7 @@ TEST_CASE("Test threaded grad", "[threaded_graph_grad]") {
     g.addArc(0, 1, i);
   }
 
-  auto add_to_grad = [&g] () {
+  auto add_to_grad = [&g]() {
     auto grad = std::vector<float>(g.numArcs(), 1);
     g.addGrad(grad);
   };
@@ -398,7 +396,7 @@ TEST_CASE("Test threaded grad", "[threaded_graph_grad]") {
   }
   // Check the grad is correct
   CHECK((std::all_of(
-    g.grad().weights(),
-    g.grad().weights() + g.numArcs(),
-    [num_threads] (float v) { return v == num_threads; })));
+      g.grad().weights(),
+      g.grad().weights() + g.numArcs(),
+      [num_threads](float v) { return v == num_threads; })));
 }

--- a/test/graph_test.cpp
+++ b/test/graph_test.cpp
@@ -179,7 +179,7 @@ TEST_CASE("Test copy", "[Graph::deepCopy]") {
 }
 
 TEST_CASE("Test arc weight get/set", "[graph setWeight weights]") {
-  std::vector<float> l = {1.1, 2.2, 3.3, 4.4};
+  std::vector<float> l = {1.1f, 2.2f, 3.3f, 4.4f};
 
   Graph g;
   g.addNode(true, false);

--- a/test/utils_test.cpp
+++ b/test/utils_test.cpp
@@ -463,7 +463,7 @@ TEST_CASE("Test SaveTxt", "[utils.saveTxt]") {
     }
     for (int i = 0; i < 10; ++i) {
       for (int j = 0; j < 10; ++j) {
-        g.addArc(i, j, i, j, i * j);
+        g.addArc(i, j, i, j, static_cast<float>(i * j));
       }
     }
     std::stringstream out;


### PR DESCRIPTION
Fix barriers to compiling on Windows with MSVC -- tested with MSVC 2019. These include:
- Missing headers
- Type narrowing and bad implicit casts.

Several operations on `Graph` use the `std::vector::size`, as do indices -- using `int` for these makes overflow possible. This changes many but not all instances of these implicit casts.

All tests pass.