### PR TITLE
Fix docs build - remove sphinx as explicit dep

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -8,7 +8,7 @@ To build the documentation, follow the steps below.
 
 Install [Doxygen](http://www.doxygen.nl/manual/install.html).
 
-Install sphinx, breathe and the theme using the `requirements.txt` file in `docs/`:
+Install `breathe` and the sphinx theme using the `requirements.txt` file in `docs/`:
 
 ```
 pip install -r requirements.txt

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,3 +1,2 @@
-sphinx
 breathe
 sphinx_rtd_theme


### PR DESCRIPTION
Docs build is broken with `sphinx` included as an explicit dependency as per https://github.com/pypa/pip/issues/9031. since `sphinx_rtd_theme` implicitly installs it, we shouldn't have this dependency issue when installing it explicitly. https://github.com/pypa/pip/issues/9031 outlines some solutions, which include removing sphinx explicitly.