### PR TITLE
Run CI on all supported platforms

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,29 +1,96 @@
-version: 2.0
+version: 2.1
+
+orbs:
+  win: circleci/windows@2.4.0
 
 jobs:
-  build:
+  linux_gcc_7_4_0:
     docker:
       - image: cimg/base:2020.01
     steps:
       - checkout
       - run:
-          name: "Build"
+          name: "Install Build Dependencies"
           command: |
             sudo apt -y update && \
-            sudo apt -y install build-essential python3-dev python3-pip cmake && \
+            sudo apt -y install build-essential python3-dev python3-pip cmake
+      - run:
+          name: "Build GTN"
+          command: |
             mkdir build && cd build && \
             cmake .. \
                   -DBUILD_SHARED_LIBS=ON \
                   -DGTN_BUILD_PYTHON_BINDINGS=ON && \
             make -j2
       - run:
-          name: "Install Python bindings"
+          name: "Install Python Bindings"
           command: |
             pip3 install packaging && \
             pip3 install numpy && \
             cd bindings/python && \
-            python3 setup.py install --user
+            python3 setup.py install --user --prefix=
       - run:
           name: "Run C++ and Python Binding Tests"
           command: |
             cd build && make test
+
+  macos_clang_11:
+    macos:
+      xcode: 11.3.0
+    environment:
+      HOMEBREW_NO_AUTO_UPDATE: "1"
+    shell: /bin/bash -eux -o pipefail
+    steps:
+      - checkout
+      - run:
+          name: "Install Build Dependencies"
+          command: |
+            brew install cmake
+      - run:
+          name: "Build GTN"
+          command: |
+            mkdir build && cd build && \
+            cmake .. \
+                  -DBUILD_SHARED_LIBS=ON \
+                  -DGTN_BUILD_PYTHON_BINDINGS=ON && \
+            make -j2
+      - run:
+          name: "Install Python Bindings"
+          command: |
+            pip3 install packaging && \
+            pip3 install numpy && \
+            cd bindings/python && \
+            python3 setup.py install --user --prefix=
+      - run:
+          name: "Run C++ and Python Binding Tests"
+          command: cd build && make test
+
+  windows_msvc_2019:
+    executor:
+      name: win/default
+      shell: bash.exe
+    steps:
+      - checkout
+      - run:
+          name: "Install Build Dependencies"
+          command: |
+            choco install cmake python3 -y
+      - run:
+          name: "Build GTN"
+          command: |
+            export PATH="$PATH:/c/Program Files/CMake/bin" && \
+            mkdir build && cd build && \
+            cmake .. \
+                  -DBUILD_SHARED_LIBS=OFF \
+                  -DGTN_BUILD_PYTHON_BINDINGS=OFF \
+                  -DCMAKE_WINDOWS_EXPORT_ALL_SYMBOLS=ON && \
+            cmake --build . --parallel 2
+
+workflows:
+  version: 2
+
+  build-and-test:
+    jobs:
+      - linux_gcc_7_4_0
+      - macos_clang_11
+      - windows_msvc_2019

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,7 +4,7 @@ orbs:
   win: circleci/windows@2.4.0
 
 jobs:
-  linux_gcc_7_4_0:
+  ubuntu_gcc_7_4_0:
     docker:
       - image: cimg/base:2020.01
     steps:
@@ -88,9 +88,8 @@ jobs:
 
 workflows:
   version: 2
-
   build-and-test:
     jobs:
-      - linux_gcc_7_4_0
+      - ubuntu_gcc_7_4_0
       - macos_clang_11
       - windows_msvc_2019

--- a/gtn/utils.cpp
+++ b/gtn/utils.cpp
@@ -11,6 +11,7 @@
 #include <list>
 #include <string>
 #include <unordered_set>
+#include <string>
 
 namespace gtn {
 

--- a/gtn/utils.cpp
+++ b/gtn/utils.cpp
@@ -11,7 +11,6 @@
 #include <list>
 #include <string>
 #include <unordered_set>
-#include <string>
 
 namespace gtn {
 


### PR DESCRIPTION
- Add separate CI jobs for macOS and Windows
- Fix some things broken with MSVC
- NB: MSVC test doesn't run tests or build Python bindings. Will come back to this later — goal is to make sure everything builds

[sorry for the many commits — it's only possible to test macOS and MSVC things by by pushing directly — these workflows can't be run locally]