### PR TITLE
[Bug] Fix compose with epsilons

### DIFF
--- a/gtn/functions/compose.cpp
+++ b/gtn/functions/compose.cpp
@@ -446,7 +446,18 @@ Graph compose(
       }
     }
 
-    // Check for output epsilons in the first graph
+    // The logic of when to check for epsilon transitions is as follows:
+    // Case 1: No epsilon match.
+    //   If there was no epsilon match then at most one of the two graphs has
+    //   an epsilon transition and we can check both safely.
+    //
+    // Case 2: Epsilon match.
+    //   If there was an epsilon match then we have to be careful to avoid
+    //   redundant paths.
+    //   1. Follow the epsilon transition out of the non accepting node.
+    //   2. If both nodes are accepting follow both transitions.
+    //   3. If neither node is accepting (arbitrarily) follow only the first
+    //   node's transition.
     if (!epsilon_matched || second.isAccept(curr.second) || !first.isAccept(curr.first)) {
       addEpsilonReachableNodes(
           false,

--- a/test/autograd_test.cpp
+++ b/test/autograd_test.cpp
@@ -214,14 +214,33 @@ TEST_CASE("Test Compose Epsilon Grad", "[functions.compose_epsilon (grad)]") {
   second.addArc(2, 3, 5, 2, 0);
   second.addArc(2, 3, gtn::epsilon, 2, 0.0); // idx 11
 
+  Graph expected =
+      loadTxt(std::stringstream("0\n"
+                                "6\n"
+                                "0 1 0 0 0\n"
+                                "0 1 0 1 0\n"
+                                "0 3 2 -1 0\n"
+                                "0 4 1 2 0\n"
+                                "1 2 0 0 0\n"
+                                "1 4 2 -1 0\n"
+                                "1 5 1 1 0\n"
+                                "2 5 2 -1 0\n"
+                                "2 6 1 0 0\n"
+                                "3 4 -1 2 0\n"
+                                "4 5 2 2 0\n"
+                                "4 5 -1 2 0\n"
+                                "5 6 2 1 0\n"
+                                "5 6 2 2 0\n"
+                                "5 6 -1 2 0\n"));
   Graph composed = compose(first, second);
+  CHECK(randEquivalent(composed, expected));
 
   backward(composed);
 
   auto& grad1 = first.grad();
   auto& grad2 = second.grad();
-  std::vector<float> expectedFirstGrad = {3, 3, 3, 5};
-  std::vector<float> expectedSecondGrad = {1, 1, 1, 2, 1, 1, 1, 3, 1, 1, 1, 2};
+  std::vector<float> expectedFirstGrad = {3, 3, 3, 3};
+  std::vector<float> expectedSecondGrad = {1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1};
   for (size_t i = 0; i < grad1.numArcs(); ++i) {
     CHECK(grad1.weights()[i] == expectedFirstGrad[i]);
   }

--- a/test/functions_test.cpp
+++ b/test/functions_test.cpp
@@ -645,6 +645,142 @@ TEST_CASE("Test Epsilon Composition", "[functions.epsilon_compose]") {
     CHECK(equal(compose(g1, g2), expected));
   }
 
+  // A series of tests making sure we handle redundant epsilon paths correctly
+  {
+    Graph g1;
+    g1.addNode(true, true);
+    g1.addArc(0, 0, 0, epsilon);
+
+    Graph g2;
+    g2.addNode(true);
+    g2.addNode(false, true);
+    g2.addArc(0, 1, epsilon, 0, 1.0);
+
+    Graph expected;
+    expected.addNode(true);
+    expected.addNode(false, true);
+    expected.addArc(0, 0, 0, epsilon);
+    expected.addArc(0, 1, epsilon, 0, 1.0);
+
+    CHECK(randEquivalent(compose(g1, g2), expected));
+  }
+
+  {
+    Graph g1;
+    g1.addNode(true, true);
+    g1.addArc(0, 0, 0, epsilon);
+
+    Graph g2;
+    g2.addNode(true, true);
+    g2.addArc(0, 0, epsilon, 0);
+
+    Graph expected;
+    expected.addNode(true, true);
+    expected.addArc(0, 0, 0, epsilon);
+    expected.addArc(0, 0, epsilon, 0);
+
+    CHECK(randEquivalent(compose(g1, g2), expected));
+  }
+
+  {
+    Graph g1;
+    g1.addNode(true, true);
+    g1.addNode(false, true);
+    g1.addArc(0, 1, 0, epsilon);
+    g1.addArc(1, 0, 0, epsilon);
+
+    Graph g2;
+    g2.addNode(true);
+    g2.addNode(false, true);
+    g2.addArc(0, 1, epsilon, 0, 1.0);
+
+    Graph expected;
+    expected.addNode(true);
+    expected.addNode(false, true);
+    expected.addArc(0, 1, epsilon, 0, 1.0);
+    expected.addArc(1, 1, 0, epsilon);
+
+    CHECK(randEquivalent(compose(g1, g2), expected));
+  }
+
+  {
+    Graph g1;
+    g1.addNode(true);
+    g1.addNode(false, true);
+    g1.addArc(0, 1, 0, epsilon);
+    g1.addArc(0, 0, 0, 1);
+
+    Graph g2;
+    g2.addNode(true);
+    g2.addNode(false, true);
+    g2.addArc(0, 1, epsilon, 0);
+    g2.addArc(0, 1, 1, 1);
+
+    Graph expected;
+    expected.addNode(true);
+    expected.addNode();
+    expected.addNode(false, true);
+    expected.addArc(0, 1, 0, 1);
+    expected.addArc(0, 1, epsilon, 0);
+    expected.addArc(1, 2, 0, epsilon);
+
+    CHECK(randEquivalent(compose(g1, g2), expected));
+  }
+
+  {
+    Graph g1;
+    g1.addNode(true);
+    g1.addNode(false, true);
+    g1.addArc(0, 1, 0, epsilon);
+    g1.addArc(0, 1, 0, 1);
+
+    Graph g2;
+    g2.addNode(true);
+    g2.addNode(false, true);
+    g2.addArc(0, 1, epsilon, 0);
+    g2.addArc(0, 0, 1, 1);
+
+    Graph expected;
+    expected.addNode(true);
+    expected.addNode();
+    expected.addNode(false, true);
+    expected.addArc(0, 1, 0, 1);
+    expected.addArc(0, 1, 0, epsilon);
+    expected.addArc(1, 2, epsilon, 0);
+
+    CHECK(randEquivalent(compose(g1, g2), expected));
+  }
+
+  {
+    Graph g1;
+    g1.addNode(true);
+    g1.addNode(false, true);
+    g1.addArc(0, 1, 0, epsilon);
+    g1.addArc(0, 1, 0, 1);
+    g1.addArc(0, 0, 1, 0);
+
+
+    Graph g2;
+    g2.addNode(true);
+    g2.addNode(false, true);
+    g2.addArc(0, 1, epsilon, 0);
+    g2.addArc(0, 0, 1, 0);
+    g2.addArc(0, 1, 0, 1);
+
+    Graph expected;
+    expected.addNode(true);
+    expected.addNode();
+    expected.addNode();
+    expected.addNode(false, true);
+    expected.addArc(0, 1, 1, 1);
+    expected.addArc(0, 1, epsilon, 0);
+    expected.addArc(0, 2, 0, 0);
+    expected.addArc(2, 3, epsilon, 0);
+    expected.addArc(1, 3, 0, epsilon);
+
+    CHECK(randEquivalent(compose(g1, g2), expected));
+  }
+
   {
     // This test case is taken from "Weighted Automata Algorithms", Mehryar
     // Mohri, https://cs.nyu.edu/~mohri/pub/hwa.pdf Section 5.1, Figure 7


### PR DESCRIPTION
There was an issue with how we handle redundant paths with epsilon composition. I think this is now fixed, and I added several test cases for this.